### PR TITLE
fix: Button internationalization not working when language is switched

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -5,6 +5,9 @@ button:
   home: Home
   toggle_dark: Toggle dark mode
   toggle_langs: Change languages
+  reset: Reset
+  copy: Copy
+  download: Download
 intro:
   title: Girid - Animation Character Preference Table
   desc: 📱 A H5 Template(Vite + Vue) inspired by Vitesse.

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -5,6 +5,9 @@ button:
   home: 首页
   toggle_dark: 切换深色模式
   toggle_langs: 切换语言
+  reset: 重置
+  copy: 复制
+  download: 下载
 intro:
   title: Girid - 动画角色印象表
   desc: 📱 固执己见的 Vite H5 项目模板

--- a/src/components/CopyGirid.vue
+++ b/src/components/CopyGirid.vue
@@ -3,6 +3,8 @@ import { toBlob } from 'html-to-image'
 
 import { copyBlobToClipboard } from 'copy-image-clipboard'
 
+const { t } = useI18n()
+
 async function onClick() {
   const container = document.getElementById('girid-container')
   if (!container)
@@ -19,7 +21,7 @@ async function onClick() {
 </script>
 
 <template>
-  <button inline-flex class="girid-btn" w="20" @click="onClick">
-    复制
+  <button inline-flex class="girid-btn" w="21" @click="onClick">
+    {{ t('button.copy') }}
   </button>
 </template>

--- a/src/components/DownloadGirid.vue
+++ b/src/components/DownloadGirid.vue
@@ -2,6 +2,8 @@
 import { downloadDataUrlAsImage } from '@yunlefun/utils'
 import { toPng } from 'html-to-image'
 
+const { t } = useI18n()
+
 async function onClick() {
   const container = document.getElementById('girid-container')
   if (!container)
@@ -18,7 +20,7 @@ async function onClick() {
 </script>
 
 <template>
-  <button inline-flex class="girid-btn" w="20" @click="onClick">
-    下载
+  <button inline-flex class="girid-btn" w="21" @click="onClick">
+    {{ t('button.download') }}
   </button>
 </template>

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -10,8 +10,8 @@ const girid = useGiridStore()
 
 <template>
   <div flex="~" justify="evenly" items="center">
-    <button inline-flex class="girid-btn" w="20" @click="girid.reset()">
-      重置
+    <button inline-flex class="girid-btn" w="21" @click="girid.reset()">
+      {{ t('button.reset') }}
     </button>
     <CopyGirid />
     <DownloadGirid />


### PR DESCRIPTION
让三个按钮的内容跟随语言切换而变化，同时增加了按钮的宽度，以便让过长的单词不会贴着按钮边框。